### PR TITLE
Features add fiber value into preview

### DIFF
--- a/Sources/PassioNutritionUIModule/NutritionUIModule/NutritionUI/Extensions/UIViewController+Extension.swift
+++ b/Sources/PassioNutritionUIModule/NutritionUIModule/NutritionUI/Extensions/UIViewController+Extension.swift
@@ -15,7 +15,7 @@ public extension UIViewController {
         let backButton = UIButton(type: .custom)
         backButton.setImage(UIImage.imageFromBundle(named: "back_arrow"), for: .normal)
         backButton.addTarget(self, action: #selector(back), for: .touchUpInside)
-        backButton.contentEdgeInsets = UIEdgeInsets(top: 0, left: -8, bottom: 0, right: 0)
+        backButton.contentEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         let backButtonItem = UIBarButtonItem(customView: backButton)
         navigationItem.leftBarButtonItem = backButtonItem
     }

--- a/Sources/PassioNutritionUIModule/NutritionUIModule/NutritionUI/Model/FoodRecordIngredient.swift
+++ b/Sources/PassioNutritionUIModule/NutritionUIModule/NutritionUI/Model/FoodRecordIngredient.swift
@@ -51,6 +51,10 @@ public struct FoodRecordIngredient: Codable, Equatable {
     public var totalFat: Double {
         nutrients.fat()?.value ?? 0
     }
+    
+    public var totalFiber: Double {
+        nutrients.fibers()?.value ?? 0
+    }
 
     public var nutritionSummary: NutritionSummary {
         (calories: totalCalories, carbs: totalCarbs, protein: totalProteins, fat: totalFat)

--- a/Sources/PassioNutritionUIModule/NutritionUIModule/NutritionUI/Model/FoodRecordV3.swift
+++ b/Sources/PassioNutritionUIModule/NutritionUIModule/NutritionUI/Model/FoodRecordV3.swift
@@ -72,6 +72,10 @@ public struct FoodRecordV3: Codable, Equatable {
     public var totalFat: Double {
         ingredients.map { $0.totalFat }.reduce(0.0, +).roundDigits(afterDecimal: 1)
     }
+    
+    public var totalFiber: Double {
+        ingredients.map { $0.totalFiber }.reduce(0.0, +).roundDigits(afterDecimal: 1)
+    }
 
     public var nutritionSummary: NutritionSummary {
         (calories: totalCalories, carbs: totalCarbs, protein: totalProteins, fat: totalFat)


### PR DESCRIPTION
See: [#516](https://github.com/Passiolife/iOS-Passio-Nutrition-SDK/issues/516)
- Added totalFiber to FoodRecord
- Added totalFiber to FoodRecordIngredient
- Fixed an issue with the back button being too small