### PR TITLE
Features/detect meal logs required

### DIFF
--- a/Sources/PassioNutritionUIModule/NutritionUIModule/NutritionUI/Extensions/Array2+Extension.swift
+++ b/Sources/PassioNutritionUIModule/NutritionUIModule/NutritionUI/Extensions/Array2+Extension.swift
@@ -35,6 +35,36 @@ extension Array where Element == UITextField {
     }
 }
 
+public extension Array where Element == DayLog {
+    func generateDataRequestJson() -> String {
+        var meals = [DayLogRecord]()
+        for dayLog in self {
+            let breakfast = dayLog.breakfastArray.compactMap({ $0.name })
+            let lunch = dayLog.lunchArray.compactMap({ $0.name })
+            let dinner = dayLog.dinnerArray.compactMap({ $0.name })
+            let snacks = dayLog.snackArray.compactMap({ $0.name })
+            let meal = DayLogRecord(date: dayLog.date.dateString,
+                                    breakfast: breakfast,
+                                    lunch: lunch,
+                                    dinner: dinner,
+                                    snacks: snacks)
+            if meal.containsData {
+                meals.append(meal)
+            }
+        }
+        
+        let encoder = JSONEncoder()
+        
+        do {
+            let data = try encoder.encode(meals)
+            let json = String(data: data, encoding: .ascii)
+            return json ?? ""
+        } catch {
+            return ""
+        }
+    }
+}
+
 // MARK: Safe use of Collection's Index while avoiding “Fatal error: Index out of range”.
 extension Collection where Indices.Iterator.Element == Index {
 

--- a/Sources/PassioNutritionUIModule/NutritionUIModule/NutritionUI/Extensions/Date+Extension.swift
+++ b/Sources/PassioNutritionUIModule/NutritionUIModule/NutritionUI/Extensions/Date+Extension.swift
@@ -9,7 +9,12 @@
 import Foundation
 
 extension Date {
-
+    var dateString: String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "MM/dd/yyyy"
+        return dateFormatter.string(from: self)
+    }
+    
     func dateFormatWithSuffix() -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "EEEE, MMMM d'\(self.daySuffix())'"

--- a/Sources/PassioNutritionUIModule/NutritionUIModule/NutritionUI/Model/DayLogRecord.swift
+++ b/Sources/PassioNutritionUIModule/NutritionUIModule/NutritionUI/Model/DayLogRecord.swift
@@ -1,0 +1,20 @@
+//
+//  DayLogRecord.swift
+//
+//
+//  Created by Davido Hyer on 8/1/24.
+//
+
+import Foundation
+
+internal struct DayLogRecord: Codable {
+    let date: String
+    let breakfast: [String]
+    let lunch: [String]
+    let dinner: [String]
+    let snacks: [String]
+    
+    var containsData: Bool {
+        !(breakfast.isEmpty && lunch.isEmpty && dinner.isEmpty && snacks.isEmpty)
+    }
+}

--- a/Sources/PassioNutritionUIModule/NutritionUIModule/NutritionUI/PassioInternalConnector.swift
+++ b/Sources/PassioNutritionUIModule/NutritionUIModule/NutritionUI/PassioInternalConnector.swift
@@ -20,6 +20,7 @@ public protocol PassioConnector: AnyObject {
     func updateRecord(foodRecord: FoodRecordV3, isNew: Bool)
     func deleteRecord(foodRecord: FoodRecordV3)
     func fetchDayRecords(date: Date, completion: @escaping ([FoodRecordV3]) -> Void)
+    func fetchMealLogsJson(daysBack: Int) -> String
 
     // User Foods
     func updateUserFood(record: FoodRecordV3, isNew: Bool)
@@ -162,6 +163,19 @@ extension PassioInternalConnector: PassioConnector {
         connector.fetchDayRecords(date: date) { (foodRecords) in
             completion(foodRecords)
         }
+    }
+    
+    public func fetchMealLogsJson(daysBack: Int) -> String {
+        let toDate = Date()
+        let fromDate = Calendar.current.date(byAdding: .day, value: -daysBack, to: toDate) ?? Date()
+
+        var dayLogs = [DayLog]()
+        PassioInternalConnector.shared.fetchDayLogRecursive(fromDate: fromDate,
+                                                            toDate: toDate) { dayLog in
+            dayLogs.append(contentsOf: dayLog)
+        }
+        let json = dayLogs.generateDataRequestJson()
+        return json
     }
 
     // MARK: UserFood


### PR DESCRIPTION
See: [#493](https://github.com/Passiolife/iOS-Passio-Nutrition-SDK/issues/493)
- Added code to provide meal log history data for Nutrition Advisor DataRequest